### PR TITLE
Add architecture plan and Electron MVP skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.DS_Store
+/dist
+/out
+/tmp
+/playwright-report
+/test-results

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# job_applier
+# AI Destekli Otomatik İş Başvuru MVP'si
+
+Bu depo, macOS üzerinde çalışacak AI destekli otomatik iş başvuru uygulamasının mimarisini, UI prototipini ve çalışır durumda minimal bir Electron örneğini içerir.
+
+## İçerik
+- `docs/` klasöründe mimari tasarım, UI hiyerarşisi ve test planı
+- `prompts/templates.json` içinde LLM prompt şablonları
+- `src/` altında Electron tabanlı masaüstü uygulama, Playwright sürücü iskeletleri ve LLM sağlayıcı soyutlaması
+- `tests/` dizininde Node test runner ile çalıştırılabilir örnek testler
+
+## Teknoloji Seçimleri
+- **Electron + Vanilla JS UI**: macOS paketleme ve hızlı prototip imkânı
+- **Playwright**: LinkedIn/Indeed/Hiring.cafe otomasyonu için temel sürücüler (stub)
+- **LLM Provider Layer**: ChatGPT/Gemini/Claude için genişletilebilir tasarım, şu an `mock` sağlayıcı örneği var
+- **Electron Store + SQLCipher planı**: Answer Vault ve ayarlar için yerel şifreli saklama
+
+## Kurulum
+1. Node.js 18+ sürümünü yükleyin (macOS için [nvm](https://github.com/nvm-sh/nvm) önerilir).
+2. Depoyu klonlayın ve dizine girin.
+3. Bağımlılıkları yükleyin:
+   ```bash
+   npm install
+   ```
+4. Elektron örneğini başlatın:
+   ```bash
+   npm start
+   ```
+   > Not: Playwright sürücüleri demo modundadır; gerçek tarama için Playwright `install` komutlarını çalıştırmanız gerekir.
+
+## Testler
+```bash
+npm test
+```
+Node test runner ile veri modeli ve prompt derleyici testleri çalışır.
+
+## Dağıtım
+- macOS için paketleme aşamasında `electron-builder` veya `electron-packager` tercih edilebilir.
+- SQLCipher kurulumu: `brew install sqlcipher` sonrası Node tarafında `better-sqlite3` + `PRAGMA key` ile entegrasyon planlanmıştır.
+
+## Örnek Akış
+1. `İlanları Tara` butonu LinkedIn/Indeed/Hiring.cafe stub sürücülerinden örnek ilanlar getirir.
+2. Her ilan kartından `CV Uyarlama` veya `Cover Letter` üretimi tetiklenir.
+3. Form soruları için Answer Vault tabanlı LLM yanıtı örneği alınır.
+
+Detaylı süreç ve kenar durumları için `docs/architecture.md` dosyasına bakın.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,174 @@
+# AI Destekli Otomatik İş Başvuru Uygulaması Mimari Dokümanı
+
+> **Varsayımlar:** Kullanıcı ilk kurulumda tüm izinleri verir, gerekli hesap girişlerini manuel yapar ve Playwright oturum açma adımlarını onaylar. CAPTCHA'lar kullanıcı tarafından çözülür. LinkedIn/Indeed/Hiring.cafe oturum açma ve başvuru süreçleri, Playwright ile web otomasyonu kapsamında mümkün olduğu ölçüde desteklenir.
+
+## 1. Üst Seviye Mimari
+
+```
++---------------------+        +------------------------+
+|  Electron Main      |        |  LLM Provider Adapter  |
+|  (macOS Desktop)    |        |  (ChatGPT/Gemini/Claude)
++----------+----------+        +-----------+------------+
+           |                               |
+           | IPC                            |
+           v                               v
++------------------------+      +--------------------------+
+| React UI (Renderer)    |<---->|  Orchestrator Service    |
+| - Onboarding           |      |  - Flow Engine           |
+| - Pipeline             |      |  - Job Matching          |
+| - Answer Vault         |      |  - Prompt Composer       |
++-----------+------------+      +--------------------------+
+            |                                   |
+            v                                   v
+  +---------------------+           +--------------------------+
+  | Secure Data Layer   |<-------->| Automation Layer         |
+  | - SQLCipher (SQLite)|          | - Playwright Drivers     |
+  | - Electron Store    |          | - Anti-bot Controls      |
+  +---------------------+          +--------------------------+
+```
+
+### Modül Sorumlulukları
+
+- **Electron Main**: Uygulama yaşam döngüsü, menü, bildirimler, macOS Keychain entegrasyonu.
+- **Renderer (React)**: UI ekranları, state yönetimi, kullanıcı etkileşimi, bildirimler ve modal akışlar.
+- **Orchestrator Service**: Başvuru sürecinin uçtan uca kontrolü. Scraper çıktıları ile LLM üretimlerini birleştirir, Answer Vault ve veri tabanı ile etkileşir.
+- **Automation Layer**: Playwright tabanlı site sürücüleri, oturum ve hız yönetimi, hata ve retry politikaları.
+- **Secure Data Layer**: SQLCipher ile şifreli veri saklama, Answer Vault için şifreli anahtar-değer deposu, macOS Keychain üzerinden API anahtar yönetimi.
+- **LLM Provider Adapter**: Seçilen tek model için generative işlevleri soyut bir arayüz altında toplar.
+
+## 2. Veri Akışları
+
+1. **Onboarding**
+   - Kullanıcı, hedef pozisyon aileleri, lokasyon, maaş bandı vb. bilgileri girer.
+   - Yanıtlar Answer Vault ve Settings tablolarına kaydedilir. Eksik bilgiler için `askForMissing()` promptu devreye girer.
+2. **İlan Toplama**
+   - Orchestrator, tanımlı filtrelere göre site sürücülerini (LinkedIn/Indeed/Hiring.cafe) tetikler.
+   - Her sürücü, hız limitleri ve rastgele beklemelerle sayfaları gezer, ilan verilerini normalize edilmiş `JobPosting` modeline dönüştürür.
+3. **İlan-Eşleşme**
+   - JobPosting verileri, profil/skill matrisine göre kural tabanlı eşleşme (keyword skor) ve LLM açıklamalı skor ile değerlendirilir.
+   - Eşik üstü ilanlar aday listesine eklenir, UI pipeline'da “Bulundu” sütununa düşer.
+4. **CV & Cover Letter Üretimi**
+   - `tailorResume()` ve `generateCoverLetter()` fonksiyonları, prompt şablonları + Answer Vault verileri + kullanıcı ön ayarları ile LLM çağrısı yapar.
+   - Oluşan dosyalar `ResumeVariant` ve `CoverLetter` kayıtlarına bağlanır. PDF/DOCX üretimi için yerel dönüştürücü (ör. `soffice --convert-to` veya macOS `qlmanage` scripti) tetiklenir.
+5. **Form Doldurma & Gönderim**
+   - Orchestrator, `applyToJob()` metoduyla Playwright form doldurma scriptini çalıştırır.
+   - Formda soru sorulduğunda Answer Vault'tan yanıt aranır, yoksa `answerFormQuestion()` promptu kullanılır. `needsUserApproval` true ise UI modalı açılır.
+   - CAPTCHA algılanırsa UI modalı ile uyarı verilir; çözüm sonrası akış kaldığı yerden devam eder.
+6. **Takip & Bildirimler**
+   - Başvuru durumu otomatik olarak “Başvuruldu” sütununa geçer. Ek notlar, loglar ve ekran görüntüsü yolları Application kaydına eklenir.
+   - Kullanıcı durum güncellemesi yaptığında (ör. HR görüşmesi), veriler pipeline state'ine yansır, hatırlatıcı planlanır.
+
+## 3. Teknoloji Seçimleri
+
+| Katman | Teknoloji | Gerekçe |
+|--------|-----------|---------|
+| UI     | **Electron + React + Tailwind** | macOS'ta tek paketle dağıtım; web tabanlı UI geliştirme verimliliği; Tailwind ile hızlı prototipleme. |
+| Otomasyon | **Playwright** | Çoklu tarayıcı desteği, insan benzeri etkileşim API'leri, güvenilir bekleme mekanizmaları. |
+| Veri | **SQLCipher (SQLite)** | Yerel şifreli veritabanı, offline çalışabilme, basit dağıtım. Node.js için `better-sqlite3` ile bağlanıp `PRAGMA key` kullanımı. |
+| LLM | **Provider Abstraction Layer** | ChatGPT, Gemini veya Claude için tek arayüz. HTTP client `fetch` ve streaming desteği. |
+| Config | **Electron Store (şifreli)** | Küçük ölçekli ayarlar için; macOS Keychain ile API anahtar depolama. |
+| Test | **Playwright Test + Node Test Runner** | Scraper senaryoları için tarayıcı temelli; modüller için hızlı unit test. |
+
+## 4. Modül Detayları
+
+### 4.1 Automation Layer
+- **BaseScraper**: Oturum yönetimi, ortak bekleme/scroll davranışları, `humanLikeActions()` yardımcıları.
+- **Site Sürücüleri**: LinkedIn, Indeed, Hiring.cafe. Her biri:
+  - Login flow (manuel giriş + cookie kaydetme).
+  - İlan listeleme, detay çekme, başvuru linki çıkarımı.
+  - Hız limiti (örn. dakikada 20 istek), retry (exponential backoff), hata loglama.
+  - robots.txt ve ToS kontrollerini config'ten okuma.
+- **Apply Flow**: Form alanlarını DOM seçicileriyle doldurma, dosya upload, onay butonları.
+
+### 4.2 LLM Provider Layer
+- `LLMProvider` arayüzü: `generateCoverLetter()`, `tailorResume()`, `answerFormQuestion()`, `askForMissing()`, `summarizeJob()`.
+- `OpenAIProvider`, `AnthropicProvider`, `GeminiProvider` sınıfları. Rate limit, streaming, hata handle.
+
+### 4.3 Data Layer
+- Şifreli SQLite tablo şeması:
+  - `user_profile`
+  - `jobs`
+  - `applications`
+  - `documents`
+  - `answer_vault`
+  - `settings`
+- SQLCipher açılışı için kullanıcı anahtarından türetilen `key` (`PBKDF2` veya `scrypt`).
+- AnswerVault için hassas alanlar (maaş, çalışma izni) AES-256 ile ek şifreleme.
+
+### 4.4 Orchestrator Service
+- `JobDiscoveryService`: arama filtreleri, scheduler (cron benzeri, macOS launchd entegrasyonu opsiyonel).
+- `MatchingEngine`: anahtar kelime skor, LLM açıklaması, eşiğe göre pipeline.
+- `DocumentService`: CV varyantı oluşturma, revizyon diff'i kaydetme.
+- `ApplicationService`: Başvuruyu tetikleme, log/ekran görüntüsü.
+- `NotificationService`: macOS native notifications (electron `Notification`).
+
+### 4.5 UI Katmanı
+- Onboarding wizard (progressive form, 3 adım).
+- Dashboard: Pipeline kanban (Bulundu, Başvuruldu, HR Görüşmesi, Teknik, Teklif, Reddedildi).
+- Job Details paneli: ilan metni, uyum skoru, generate/resume buttons.
+- Answer Vault ekranı: soru-yanıt listesi, edit.
+- Ayarlar: LLM seçimi, hız limitleri, captcha bildirim modu, siyah/beyaz liste.
+- Log Center: Akış logları, ekran görüntüsü thumb, hata filtreleme.
+
+## 5. Güvenlik ve Gizlilik
+- **PII Şifreleme**: SQLCipher `PRAGMA cipher_page_size = 4096; PRAGMA kdf_iter = 64000`. Kişisel veriler AES-GCM ile ayrıca sarılır.
+- **API Anahtarları**: macOS Keychain (electron `keytar` modülü) üzerinden saklanır.
+- **Veri İhracı**: JSON/CSV dışa aktarma; kullanıcı onayı, dosyalar `~/Documents/JobApplierExports` dizinine şifreli olarak yazılır.
+- **Log Masking**: Otomasyon loglarında PII maskeleme.
+- **ToS Uyum**: Filtre ayarlarında robots.txt denetimi, throttle, manuel captcha.
+
+## 6. Hata ve Kenar Durumları
+- Giriş başarısız → 3 deneme, sonra kullanıcıya bildirim + manuel müdahale.
+- CAPTCHA algısı → modal + adım kaydı; 5 dakikada çözülmezse zaman aşımı.
+- LLM yanıtı tutarsız/boş → otomatik yeniden deneme (maks. 2), sonra kullanıcıya prompt tweak önerisi.
+- Dosya yükleme hatası → pipeline “Eksik” durumuna al, UI’da tekrar dene butonu.
+- İnternet kesilmesi → scheduler duraklatma, tekrar bağlanınca kaldığı yerden.
+
+## 7. Zamanlama ve Pipeline Yönetimi
+- Günlük başvuru limiti ve takvim: Scheduler, kullanıcı tanımlı saat aralığında (örn. 09:00-20:00) çalışır.
+- Batch mod: Gece tarama, gündüz başvuru.
+- Manuel mod: Kullanıcı ilan seçip "Şimdi Başvur" der.
+
+## 8. Örnek Dosya Yapısı
+
+```
+job_applier/
+├── docs/
+│   ├── architecture.md
+│   ├── test_plan.md
+│   └── ui_prototype.md
+├── prompts/
+│   └── templates.json
+├── src/
+│   ├── automation/
+│   │   ├── baseScraper.js
+│   │   ├── linkedinScraper.js
+│   │   ├── indeedScraper.js
+│   │   └── hiringCafeScraper.js
+│   ├── data/
+│   │   ├── models.js
+│   │   └── vault.js
+│   ├── llm/
+│   │   ├── providerFactory.js
+│   │   └── promptComposer.js
+│   ├── pipeline/
+│   │   └── orchestrator.js
+│   ├── main.js
+│   ├── preload.js
+│   └── ui/
+│       ├── app.js
+│       ├── index.html
+│       └── styles.css
+├── tests/
+│   └── data-models.test.js
+├── package.json
+└── README.md
+```
+
+## 9. Ölçümler & Başarı Kriterleri
+- Başvuru tamamlama oranı ≥ %80 (manuel müdahale gerekmeyen).
+- CAPTCHA'larda kullanıcı müdahalesi < %20.
+- CV/CL üretim süresi < 60 saniye.
+- Günlük başvuru limiti uyması (%100).
+- Hata loglarına göre otomasyon retry sonrası başarı ≥ %70.
+

--- a/docs/test_plan.md
+++ b/docs/test_plan.md
@@ -1,0 +1,42 @@
+# Test Planı ve Başarı Ölçütleri
+
+## 1. Test Yaklaşımı
+- **Modüler Unit Testler**: Veri modelleri, skor hesaplamaları, prompt composer fonksiyonları Node test runner ile doğrulanır.
+- **Servis Entegrasyon Testleri**: Orchestrator'ın LLM, Answer Vault ve otomasyon katmanını orkestre etmesi mocking ile test edilir.
+- **Playwright E2E**: Scraper sürücüleri ve form doldurma akışları için gerçek tarayıcı testleri (headless + slowMo) çalıştırılır.
+- **Güvenlik Testleri**: Şifreli veritabanı açılışı, anahtar rotasyonu, PII maskeleme.
+- **Performans Testleri**: Günlük başvuru limiti senaryosu, 50 ilanlık batch eşleştirme.
+
+## 2. Test Senaryoları
+
+| ID | Senaryo | Adımlar | Beklenen |
+|----|---------|--------|----------|
+| UT-01 | UserProfile kaydı | `saveUserProfile()` | Veri tabanına şifreli kaydedilir. |
+| UT-02 | Answer Vault yazma | `upsertAnswer()` | Tekil questionKey, tarih güncellenir. |
+| UT-03 | Prompt composer | `composeTailorResumePrompt()` | Şablonda gerekli alanlar doldurulur. |
+| ST-01 | İş tarama | LinkedIn sürücüsü mock HTML | Normalize `JobPosting` döner. |
+| ST-02 | Eşleşme skoru | `MatchingEngine.match()` | Eşik üzeri/altı doğru ayrılır. |
+| ST-03 | Başvuru akışı | `ApplicationService.apply()` | CAPTCHA modalı tetikler, pause/resume. |
+| E2E-01 | Başvuru tam akışı | Onboarding → tarama → başvuru | Pipeline "Başvuruldu" güncellenir, loglar kaydedilir. |
+| SEC-01 | Keychain erişimi | Sahte anahtar | Yetkisiz erişim reddi loglanır. |
+| PERF-01 | Günlük limit | 12 başvuru denemesi | İlk 10 işlenir, kalanlar ertelenir. |
+
+## 3. Test Ortamı
+- macOS 13+ (Apple Silicon uyumlu).
+- Node.js 18 LTS, npm 9+
+- Playwright Chromium + WebKit (LinkedIn/Indeed uyumu için WebKit fallback).
+- SQLCipher yüklü (`brew install sqlcipher`).
+
+## 4. Otomasyon Pipeline'ı
+- `npm run test` → Unit test (Node `--test`).
+- `npm run test:e2e` → Playwright test (gelecekte).
+- `npm run lint` → Script (şimdilik placeholder, ileride ESLint + Prettier).
+- CI: GitHub Actions (macOS runner) + gece planlı smoke test.
+
+## 5. Başarı Ölçütleri
+- Test coverage (unit + service) ≥ %70.
+- Playwright e2e senaryolarında başarı ≥ %80.
+- Ortalama başvuru süresi (tarama + uygulama) ≤ 3 dk.
+- Manuel müdahale gerektiren başvuru oranı ≤ %20.
+- Kritik hata (otomasyon crash) sıklığı ≤ haftada 1.
+

--- a/docs/ui_prototype.md
+++ b/docs/ui_prototype.md
@@ -1,0 +1,136 @@
+# UI Prototipi ve Component Hiyerarşisi
+
+> **Varsayım:** MVP aşamasında React + Tailwind kullanılıyor, durum yönetimi için Zustand tercih ediliyor.
+
+## 1. Ekranlar
+
+1. **Onboarding Sihirbazı**
+   - Adım 1: Profil Temel Bilgiler (isim, iletişim, roller).
+   - Adım 2: Tercihler (lokasyon, maaş, çalışma modeli, vize).
+   - Adım 3: CV yükleme, LLM modeli seçimi, günlük limit.
+2. **Dashboard**
+   - Sol tarafta filtre paneli (rol, lokasyon, kaynak site, skor aralığı).
+   - Sağda Kanban pipeline (Bulundu → Başvuruldu → HR Görüşmesi → Teknik → Teklif → Reddedildi).
+3. **Job Detayı Drawer**
+   - İlan metni, gereksinim listesi, skor breakdown.
+   - Aksiyon butonları: "CV'yi Uyarlayın", "Cover Letter Oluştur", "Başvuruyu Başlat".
+4. **Answer Vault**
+   - Soru-anahtar listesi, kategori filtreleri (Maaş, Vize, Çalışma Modeli, Diğer).
+   - Inline edit ve versiyon geçmişi.
+5. **Ayarlar**
+   - Model seçimi, hız limitleri, captcha modal davranışı, siyah/beyaz listeler, veri ihracı.
+6. **Log & Diagnostik**
+   - Son başvurular listesi, durum, hata mesajı, ekran görüntüsü önizleme.
+
+## 2. Component Hiyerarşisi
+
+```
+<AppShell>
+  <SideNav />
+  <HeaderBar />
+  <ContentArea>
+    <Route path="/onboarding">
+      <OnboardingWizard>
+        <StepProfile />
+        <StepPreferences />
+        <StepUploads />
+      </OnboardingWizard>
+    </Route>
+    <Route path="/dashboard">
+      <DashboardLayout>
+        <FilterPanel />
+        <KanbanBoard>
+          <Column status="found">
+            <JobCard />
+          </Column>
+          ...
+        </KanbanBoard>
+      </DashboardLayout>
+      <JobDrawer />
+    </Route>
+    <Route path="/vault">
+      <AnswerVaultPage>
+        <VaultList />
+        <VaultDetail />
+      </AnswerVaultPage>
+    </Route>
+    <Route path="/settings">
+      <SettingsPage>
+        <ModelSelector />
+        <RateLimitForm />
+        <ListManager type="blacklist" />
+        <ExportSection />
+      </SettingsPage>
+    </Route>
+    <Route path="/logs">
+      <LogPage>
+        <LogTable />
+        <ScreenshotModal />
+      </LogPage>
+    </Route>
+  </ContentArea>
+  <ToastHub />
+  <CaptchaModal />
+  <PromptTuningSheet />
+</AppShell>
+```
+
+## 3. State Yönetimi
+
+### Global Store (Zustand)
+- `userProfile`
+- `settings`
+- `answerVault`
+- `jobs` (liste + filtre)
+- `applications`
+- `ui` (modallar, toasts, yükleme durumları)
+- `prompts` (kullanıcı override'ları)
+
+### Derived State / Selectors
+- `selectJobsByStatus(status)`
+- `selectJobById(id)`
+- `selectVaultEntry(key)`
+- `selectDailyProgress()`
+
+### Async Actions
+- `fetchJobs()` → Orchestrator IPC çağrısı.
+- `startApplication(jobId)` → otomasyon tetikleme.
+- `saveVaultEntry()` → AnswerVault service.
+- `updateSettings()` → Keychain + Store güncelleme.
+
+## 4. Veri Modelleri UI'da
+
+```
+type PipelineColumn = {
+  id: string;
+  title: string;
+  status: ApplicationStatus;
+  limit?: number;
+};
+
+type JobCardVM = {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+  matchScore: number;
+  updatedAt: string;
+  hasNewEvents: boolean;
+};
+
+type VaultEntryVM = {
+  questionKey: string;
+  answer: string;
+  category: string;
+  updatedAt: string;
+  needsReview: boolean;
+};
+```
+
+## 5. UX Notları
+- İnsan benzeri otomasyon durumları UI'da “devam ediyor” spinner + iptal butonu ile gösterilir.
+- CAPTCHA uyarısı, modal + adım açıklaması + "Çözdüm" butonu.
+- İlk açılışta onboarding zorunlu, tamamlanmadan dashboard açılmaz.
+- Pipeline kartları drag&drop (React Beautiful DnD veya alternatif), manuel durum değişikliğini destekler.
+- Log sayfası filtreleri (kaynak, tarih, durum) ve CSV indirme.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1173 @@
+{
+  "name": "job-applier",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "job-applier",
+      "version": "0.1.0",
+      "dependencies": {
+        "electron-store": "^9.0.0",
+        "uuid": "^9.0.1"
+      },
+      "devDependencies": {
+        "electron": "^28.2.3",
+        "playwright": "^1.41.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.127",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
+      "integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
+      "integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
+      "dependencies": {
+        "stubborn-fs": "^1.2.5",
+        "when-exit": "^2.1.1"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-12.0.0.tgz",
+      "integrity": "sha512-fIWyWUXrJ45cHCIQX+Ck1hrZDIf/9DR0P0Zewn3uNht28hbt5OfGUq8rRWsxi96pZWPyBEd0eY9ama01JTaknA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^2.0.2",
+        "debounce-fn": "^5.1.2",
+        "dot-prop": "^8.0.2",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.5.4",
+        "uint8array-extras": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
+      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dot-prop": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-8.0.2.tgz",
+      "integrity": "sha512-xaBe6ZT4DHPkg0k4Ytbvn5xoxgpG0jOS1dYxSOwAHPuNLjP3/OzN0gH55SrLqpx8cBfSaVt91lXYkApjb+nYdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron": {
+      "version": "28.3.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-28.3.3.tgz",
+      "integrity": "sha512-ObKMLSPNhomtCOBAxFS8P2DW/4umkh72ouZUlUKzXGtYuPzgr1SYhskhFWgzAsPtUzhL2CzyV2sfbHcEW4CXqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^18.11.18",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-store": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-9.0.0.tgz",
+      "integrity": "sha512-7LZ2dR3N3bF93G2c4x+1NZ/8fpsKv6bKrMxeOQWLqdRbxvopxVqy9QXQy9axSV2O3P1kVGTj1q2wq5/W4isiOg==",
+      "license": "MIT",
+      "dependencies": {
+        "conf": "^12.0.0",
+        "type-fest": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
+      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/stubborn-fs": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
+      "integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g=="
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-0.3.0.tgz",
+      "integrity": "sha512-erJsJwQ0tKdwuqI0359U8ijkFmfiTcq25JvvzRVc1VP+2son1NJRXhxcAKJmAW3ajM8JSGAfsAXye8g4s+znxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.4.tgz",
+      "integrity": "sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "job-applier",
+  "version": "0.1.0",
+  "description": "Mac i\u00e7in AI destekli otomatik i\u015f ba\u015fvuru uygulamas\u0131 i\u00e7in MVP iskeleti",
+  "type": "module",
+  "main": "src/main.js",
+  "scripts": {
+    "start": "electron .",
+    "lint": "node scripts/lint.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "electron-store": "^9.0.0",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "electron": "^28.2.3",
+    "playwright": "^1.41.0"
+  }
+}

--- a/prompts/templates.json
+++ b/prompts/templates.json
@@ -1,0 +1,18 @@
+{
+  "resume_tailoring": {
+    "name": "İlan → CV Uyarlama",
+    "prompt": "Görev: Aşağıdaki iş ilanına göre CV’yi ATS uyumlu şekilde özelleştir. Kısıtlar: Doğru ve dürüst ol, uydurma ekleme yapma. 1 sayfa öncelikli.  Çıktı: Bölüm bazlı değişiklik listesi + nihai düz metin CV. Girdiler: - İlan (dilini algıla ve aynı dilde yaz): {{JOB_TEXT}} - Mevcut CV (dilini koru veya ilan diline çevir): {{RESUME_TEXT}} - Vurgulanacak beceriler: {{TARGET_SKILLS?}}"
+  },
+  "cover_letter": {
+    "name": "Cover Letter",
+    "prompt": "Görev: İlan için tek sayfa cover letter oluştur. Ton: {{TONE}}  Dil: {{LANG}} Çıktı: Başlık, selamlama, 3–4 paragraf, imza. Girdiler: - İlan: {{JOB_TEXT}} - Kısa başarılar ve metrikler: {{ACHIEVEMENTS}} - Şirket/ürün hakkında iki nokta: {{COMPANY_NOTES}}"
+  },
+  "form_qa": {
+    "name": "Form Soru-Cevap",
+    "prompt": "Görev: Aşağıdaki soruyu, kullanıcı profilini ve AnswerVault'u esas alarak yanıtla. Eğer Vault'da veri yoksa “Kullanıcı Onayı Gerekli” de ve 2–3 makul öneri üret. Girdiler: - Soru: {{QUESTION}} - UserProfile: {{PROFILE}} - AnswerVault: {{VAULT}} Çıktı: { answer, needsUserApproval: true|false, suggestions?: [] }"
+  },
+  "missing_info": {
+    "name": "Eksik Bilgi Sorma",
+    "prompt": "Görev: Eksik kritik alanlar için kullanıcıya en az ağrısız, kısa sorular sor. Kurallar: Tek seferde en fazla 3 soru; çoktan seçmeli öneriler sun; cevaplandığında AnswerVault'a kaydet. Girdiler: {{MISSING_FIELDS_LIST}} Çıktı: { questions: [{q, options[]?}] }"
+  }
+}

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('Lint checks are not implemented in this MVP skeleton.');

--- a/src/automation/baseScraper.js
+++ b/src/automation/baseScraper.js
@@ -1,0 +1,48 @@
+import { setTimeout as wait } from 'node:timers/promises';
+
+/**
+ * Playwright tabanlı sürücüler için temel sınıf
+ */
+export class BaseScraper {
+  /**
+   * @param {{ playwright: import('playwright').BrowserContext, config: any }} options
+   */
+  constructor({ playwright, config }) {
+    this.context = playwright;
+    this.config = config;
+  }
+
+  /**
+   * İnsan benzeri etkileşim için gecikme
+   * @param {number} min
+   * @param {number} max
+   */
+  async humanDelay(min = 200, max = 750) {
+    const delta = Math.random() * (max - min) + min;
+    await wait(delta);
+  }
+
+  async scrollPage(page) {
+    await page.mouse.wheel(0, 400 + Math.random() * 200);
+    await this.humanDelay();
+  }
+
+  async throttle(siteKey = 'global') {
+    const limit = this.config.rateLimits?.[siteKey] ?? this.config.rateLimits?.global ?? 30;
+    const interval = Math.ceil(60000 / limit);
+    await wait(interval + Math.random() * 120);
+  }
+
+  async withRetry(fn, attempts = 3) {
+    let lastError;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        return await fn();
+      } catch (error) {
+        lastError = error;
+        await wait(500 * (i + 1));
+      }
+    }
+    throw lastError;
+  }
+}

--- a/src/automation/hiringCafeScraper.js
+++ b/src/automation/hiringCafeScraper.js
@@ -1,0 +1,27 @@
+import { BaseScraper } from './baseScraper.js';
+import { v4 as uuid } from 'uuid';
+
+export class HiringCafeScraper extends BaseScraper {
+  async searchJobs(params) {
+    await this.throttle('hiringCafe');
+    return [
+      {
+        id: uuid(),
+        source: 'hiring.cafe',
+        url: 'https://hiring.cafe/jobs/789',
+        title: 'Product Designer',
+        company: 'Remote Startup',
+        location: params.location ?? 'Remote',
+        description: 'Design systems, UX research, Figma uzmanlığı.',
+        skills: ['Design Systems', 'UX Research', 'Figma'],
+        salaryHint: {},
+        applyMethod: 'external'
+      }
+    ];
+  }
+
+  async apply(job) {
+    await this.throttle('hiringCafe');
+    return { success: true, steps: ['externalRedirect'] };
+  }
+}

--- a/src/automation/indeedScraper.js
+++ b/src/automation/indeedScraper.js
@@ -1,0 +1,27 @@
+import { BaseScraper } from './baseScraper.js';
+import { v4 as uuid } from 'uuid';
+
+export class IndeedScraper extends BaseScraper {
+  async searchJobs(params) {
+    await this.throttle('indeed');
+    return [
+      {
+        id: uuid(),
+        source: 'indeed',
+        url: 'https://tr.indeed.com/viewjob?jk=456',
+        title: 'Senior Software Engineer',
+        company: 'Teknoloji AŞ',
+        location: params.location ?? 'İstanbul',
+        description: 'Node.js ve Playwright otomasyon deneyimi.',
+        skills: ['Node.js', 'Playwright', 'Automation'],
+        salaryHint: { currency: 'TRY', min: 900000, max: 1200000 },
+        applyMethod: 'platform'
+      }
+    ];
+  }
+
+  async apply(job) {
+    await this.throttle('indeed');
+    return { success: true, steps: ['loginCheck', 'fileUpload', 'submit'] };
+  }
+}

--- a/src/automation/linkedinScraper.js
+++ b/src/automation/linkedinScraper.js
@@ -1,0 +1,36 @@
+import { BaseScraper } from './baseScraper.js';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * LinkedIn sürücüsü (stub)
+ */
+export class LinkedInScraper extends BaseScraper {
+  /**
+   * @param {{ filters: Record<string, any> }} params
+   */
+  async searchJobs(params) {
+    await this.throttle('linkedin');
+    return [
+      {
+        id: uuid(),
+        source: 'linkedin',
+        url: 'https://www.linkedin.com/jobs/view/123',
+        title: 'Senior Product Manager',
+        company: 'Örnek Şirket',
+        location: params.location ?? 'Remote',
+        description: 'Ürün stratejisi ve çapraz ekip iş birliği.',
+        skills: ['Product Strategy', 'Roadmap', 'Stakeholder Management'],
+        salaryHint: {},
+        applyMethod: 'platform'
+      }
+    ];
+  }
+
+  /**
+   * @param {import('../data/models.js').JobPosting} job
+   */
+  async apply(job) {
+    await this.throttle('linkedin');
+    return { success: true, steps: ['loginCheck', 'formFill', 'submit'] };
+  }
+}

--- a/src/data/models.js
+++ b/src/data/models.js
@@ -1,0 +1,158 @@
+/**
+ * Ortak veri modelleri ve yardımcıları
+ * Not: SQLCipher gerçek kullanımı için native modüller gerekir; bu dosya sadece şema ve temel doğrulama sağlar.
+ */
+
+/**
+ * @typedef {Object} UserProfile
+ * @property {string} name
+ * @property {string} email
+ * @property {string[]} locations
+ * @property {string[]} roles
+ * @property {string[]} skills
+ * @property {Array<{code: string, level: 'beginner'|'intermediate'|'advanced'|'native'}>} languages
+ * @property {string} workAuth
+ * @property {boolean} relocation
+ * @property {{ currency: string, min: number, max: number }} salaryRange
+ * @property {string} noticePeriod
+ * @property {string} createdAt
+ */
+
+/**
+ * @typedef {Object} ResumeVariant
+ * @property {string} id
+ * @property {string} baseResumeRef
+ * @property {string} jobId
+ * @property {string} diff
+ * @property {{ pdf?: string, docx?: string }} filePaths
+ */
+
+/**
+ * @typedef {Object} CoverLetter
+ * @property {string} id
+ * @property {string} jobId
+ * @property {string} text
+ * @property {'tr'|'en'} language
+ * @property {string} tone
+ */
+
+/**
+ * @typedef {Object} JobPosting
+ * @property {string} id
+ * @property {string} source
+ * @property {string} url
+ * @property {string} title
+ * @property {string} company
+ * @property {string} location
+ * @property {string} description
+ * @property {string[]} skills
+ * @property {{ currency?: string, min?: number, max?: number }} salaryHint
+ * @property {string} applyMethod
+ */
+
+/**
+ * @typedef {Object} Application
+ * @property {string} id
+ * @property {string} jobId
+ * @property {string} resumeVariantId
+ * @property {string} coverLetterId
+ * @property {'found'|'applied'|'hr'|'tech'|'offer'|'rejected'} status
+ * @property {{ createdAt: string, updatedAt: string, submittedAt?: string }} timestamps
+ * @property {string} notes
+ * @property {{ screenshot?: string, logPath?: string }} evidence
+ */
+
+/**
+ * @typedef {Object} AnswerVaultEntry
+ * @property {string} questionKey
+ * @property {string} answer
+ * @property {'tr'|'en'} lang
+ * @property {string} updatedAt
+ */
+
+/**
+ * @typedef {Object} Settings
+ * @property {'chatgpt'|'gemini'|'claude'} provider
+ * @property {number} dailyCap
+ * @property {{ global: number, linkedin: number, indeed: number, hiringCafe: number }} rateLimits
+ * @property {string[]} blacklists
+ * @property {string[]} whitelists
+ * @property {boolean} nightMode
+ */
+
+/**
+ * @param {Partial<UserProfile>} profile
+ * @returns {UserProfile}
+ */
+export function createUserProfile(profile = {}) {
+  const now = new Date();
+  return {
+    name: profile.name ?? 'Ad Soyad',
+    email: profile.email ?? 'example@email.com',
+    locations: profile.locations ?? [],
+    roles: profile.roles ?? [],
+    skills: profile.skills ?? [],
+    languages: profile.languages ?? [{ code: 'tr', level: 'native' }],
+    workAuth: profile.workAuth ?? 'Belirtilmedi',
+    relocation: profile.relocation ?? false,
+    salaryRange:
+      profile.salaryRange ??
+      {
+        currency: 'TRY',
+        min: 0,
+        max: 0
+      },
+    noticePeriod: profile.noticePeriod ?? 'Hazır',
+    createdAt: now.toISOString()
+  };
+}
+
+/**
+ * @param {Partial<Settings>} settings
+ * @returns {Settings}
+ */
+export function createDefaultSettings(settings = {}) {
+  return {
+    provider: settings.provider ?? 'chatgpt',
+    dailyCap: settings.dailyCap ?? 10,
+    rateLimits:
+      settings.rateLimits ??
+      {
+        global: 30,
+        linkedin: 15,
+        indeed: 15,
+        hiringCafe: 10
+      },
+    blacklists: settings.blacklists ?? [],
+    whitelists: settings.whitelists ?? [],
+    nightMode: settings.nightMode ?? false
+  };
+}
+
+/**
+ * İlan eşleşmesi için skor hesaplama (basit anahtar kelime oranı)
+ * @param {JobPosting} job
+ * @param {UserProfile} profile
+ * @returns {{ score: number, matchedSkills: string[] }}
+ */
+export function computeMatchScore(job, profile) {
+  const skills = job.skills ?? [];
+  const profileSkills = new Set((profile.skills ?? []).map((s) => s.toLowerCase()));
+  if (skills.length === 0 || profileSkills.size === 0) {
+    return { score: 0, matchedSkills: [] };
+  }
+  const matched = skills.filter((skill) => profileSkills.has(skill.toLowerCase()));
+  const score = Math.round((matched.length / skills.length) * 100);
+  return { score, matchedSkills: matched };
+}
+
+/**
+ * @param {Application[]} applications
+ * @returns {Record<string, number>}
+ */
+export function summarizePipeline(applications) {
+  return applications.reduce((acc, app) => {
+    acc[app.status] = (acc[app.status] ?? 0) + 1;
+    return acc;
+  }, /** @type {Record<string, number>} */ ({}));
+}

--- a/src/data/vault.js
+++ b/src/data/vault.js
@@ -1,0 +1,46 @@
+import Store from 'electron-store';
+
+const vaultStore = new Store({
+  name: 'answer-vault',
+  encryptionKey: undefined // Gerçek uygulamada kullanıcı anahtarından türetilmeli
+});
+
+/**
+ * @param {string} questionKey
+ * @returns {import('./models.js').AnswerVaultEntry | undefined}
+ */
+export function getAnswer(questionKey) {
+  return vaultStore.get(questionKey);
+}
+
+/**
+ * @param {import('./models.js').AnswerVaultEntry} entry
+ */
+export function upsertAnswer(entry) {
+  vaultStore.set(entry.questionKey, entry);
+}
+
+/**
+ * @returns {Record<string, import('./models.js').AnswerVaultEntry>}
+ */
+export function listAnswers() {
+  return vaultStore.store;
+}
+
+/**
+ * @param {string} questionKey
+ */
+export function removeAnswer(questionKey) {
+  vaultStore.delete(questionKey);
+}
+
+/**
+ * Cevap kasasına toplu import
+ * @param {Array<import('./models.js').AnswerVaultEntry>} entries
+ */
+export function importAnswers(entries) {
+  for (const entry of entries) {
+    upsertAnswer(entry);
+  }
+}
+

--- a/src/llm/promptComposer.js
+++ b/src/llm/promptComposer.js
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const templates = JSON.parse(
+  readFileSync(join(__dirname, '../../prompts/templates.json'), 'utf-8')
+);
+
+/**
+ * @param {'resume_tailoring'|'cover_letter'|'form_qa'|'missing_info'} key
+ * @param {Record<string, unknown>} variables
+ */
+export function composePrompt(key, variables) {
+  const template = templates[key];
+  if (!template) {
+    throw new Error(`Prompt template bulunamadı: ${key}`);
+  }
+  return Object.entries(variables).reduce((acc, [name, value]) => {
+    const placeholder = `{{${name}}}`;
+    return acc.replaceAll(placeholder, serializeValue(value));
+  }, template.prompt);
+}
+
+function serializeValue(value) {
+  if (value == null) return '';
+  if (Array.isArray(value)) return value.join(', ');
+  if (typeof value === 'object') {
+    return JSON.stringify(value, null, 2);
+  }
+  return String(value);
+}
+
+export function listPrompts() {
+  return templates;
+}

--- a/src/llm/providerFactory.js
+++ b/src/llm/providerFactory.js
@@ -1,0 +1,71 @@
+/**
+ * LLM sağlayıcı soyutlaması
+ */
+
+class BaseProvider {
+  /**
+   * @param {{ apiKey: string }} options
+   */
+  constructor(options) {
+    this.apiKey = options.apiKey;
+  }
+
+  async generateCoverLetter(payload) {
+    throw new Error('Not implemented');
+  }
+
+  async tailorResume(payload) {
+    throw new Error('Not implemented');
+  }
+
+  async answerFormQuestion(payload) {
+    throw new Error('Not implemented');
+  }
+
+  async askForMissing(payload) {
+    throw new Error('Not implemented');
+  }
+}
+
+class MockProvider extends BaseProvider {
+  async generateCoverLetter({ jobText, achievements, tone, language }) {
+    return `(${language?.toUpperCase() ?? 'TR'} | ${tone}) ${achievements?.join(', ') ?? ''}\n${jobText.slice(0, 120)}...`;
+  }
+
+  async tailorResume({ jobText, resumeText }) {
+    return {
+      diff: ['Deneyim bölümünü ilan gereksinimlerine göre güncelleyin.'],
+      resume: `${resumeText}\n\n---\nUyarlanan Özet:\n${jobText.slice(0, 200)}...`
+    };
+  }
+
+  async answerFormQuestion({ question }) {
+    return {
+      answer: `Örnek yanıt: ${question.slice(0, 80)}...`,
+      needsUserApproval: false
+    };
+  }
+
+  async askForMissing({ missingFields }) {
+    const questions = missingFields.slice(0, 3).map((field) => ({
+      q: `${field} bilgisini paylaşır mısınız?`,
+      options: []
+    }));
+    return { questions };
+  }
+}
+
+/**
+ * @param {'chatgpt'|'gemini'|'claude'|'mock'} provider
+ * @param {{ apiKey: string }} options
+ */
+export function createProvider(provider, options) {
+  switch (provider) {
+    case 'mock':
+      return new MockProvider(options);
+    default:
+      return new BaseProvider(options);
+  }
+}
+
+export { BaseProvider };

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,77 @@
+import { app, BrowserWindow, ipcMain, Notification } from 'electron';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { Orchestrator } from './pipeline/orchestrator.js';
+import { createProvider } from './llm/providerFactory.js';
+import { LinkedInScraper } from './automation/linkedinScraper.js';
+import { IndeedScraper } from './automation/indeedScraper.js';
+import { HiringCafeScraper } from './automation/hiringCafeScraper.js';
+import { createUserProfile, createDefaultSettings } from './data/models.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let mainWindow;
+
+const settings = createDefaultSettings();
+const profile = createUserProfile({ name: 'Demo Kullanıcı', email: 'demo@example.com' });
+
+const provider = createProvider('mock', { apiKey: '' });
+const scraperConfig = { rateLimits: settings.rateLimits };
+const scrapers = {
+  linkedin: new LinkedInScraper({ playwright: /** @type {any} */ (null), config: scraperConfig }),
+  indeed: new IndeedScraper({ playwright: /** @type {any} */ (null), config: scraperConfig }),
+  hiringCafe: new HiringCafeScraper({ playwright: /** @type {any} */ (null), config: scraperConfig })
+};
+
+const orchestrator = new Orchestrator({ provider, scrapers, profile });
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      preload: join(__dirname, 'preload.js')
+    }
+  });
+
+  mainWindow.loadFile(join(__dirname, 'ui/index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+ipcMain.handle('orchestrator:discoverJobs', async (_event, filters) => {
+  const results = await orchestrator.discoverJobs({ filters });
+  return results;
+});
+
+ipcMain.handle('orchestrator:buildResume', async (_event, { job, resume }) => {
+  return orchestrator.buildResume(job, resume);
+});
+
+ipcMain.handle('orchestrator:buildCoverLetter', async (_event, { job, achievements, tone, language }) => {
+  const coverLetter = await orchestrator.buildCoverLetter(job, achievements, tone, language);
+  new Notification({
+    title: 'Cover Letter Hazır',
+    body: `${job.title} için taslak oluşturuldu.`
+  }).show();
+  return coverLetter;
+});
+
+ipcMain.handle('orchestrator:answerQuestion', async (_event, { question, vaultEntry }) => {
+  return orchestrator.answerQuestion(question, vaultEntry);
+});

--- a/src/pipeline/orchestrator.js
+++ b/src/pipeline/orchestrator.js
@@ -1,0 +1,72 @@
+import { composePrompt } from '../llm/promptComposer.js';
+import { computeMatchScore } from '../data/models.js';
+
+/**
+ * Basit orchestrator örneği
+ */
+export class Orchestrator {
+  /**
+   * @param {{
+   *  provider: import('../llm/providerFactory.js').BaseProvider,
+   *  scrapers: {
+   *    linkedin: import('../automation/linkedinScraper.js').LinkedInScraper,
+   *    indeed: import('../automation/indeedScraper.js').IndeedScraper,
+   *    hiringCafe: import('../automation/hiringCafeScraper.js').HiringCafeScraper
+   *  },
+   *  profile: import('../data/models.js').UserProfile
+   * }} deps
+   */
+  constructor({ provider, scrapers, profile }) {
+    this.provider = provider;
+    this.scrapers = scrapers;
+    this.profile = profile;
+  }
+
+  /**
+   * @param {{ filters: Record<string, any> }} params
+   */
+  async discoverJobs(params) {
+    const results = await Promise.all([
+      this.scrapers.linkedin.searchJobs(params),
+      this.scrapers.indeed.searchJobs(params),
+      this.scrapers.hiringCafe.searchJobs(params)
+    ]);
+    const jobs = results.flat();
+    return jobs.map((job) => ({
+      job,
+      match: computeMatchScore(job, this.profile)
+    }));
+  }
+
+  /**
+   * @param {import('../data/models.js').JobPosting} job
+   */
+  async buildResume(job, resumeText) {
+    const prompt = composePrompt('resume_tailoring', {
+      JOB_TEXT: job.description,
+      RESUME_TEXT: resumeText,
+      TARGET_SKILLS: job.skills
+    });
+    return this.provider.tailorResume({ jobText: job.description, resumeText, prompt });
+  }
+
+  async buildCoverLetter(job, achievements, tone = 'samimi', language = 'tr') {
+    const prompt = composePrompt('cover_letter', {
+      JOB_TEXT: job.description,
+      ACHIEVEMENTS: achievements,
+      COMPANY_NOTES: `${job.company} hakkında araştırma notları`,
+      TONE: tone,
+      LANG: language
+    });
+    return this.provider.generateCoverLetter({ jobText: job.description, achievements, tone, language, prompt });
+  }
+
+  async answerQuestion(question, vaultEntry) {
+    const prompt = composePrompt('form_qa', {
+      QUESTION: question,
+      PROFILE: this.profile,
+      VAULT: vaultEntry ?? {}
+    });
+    return this.provider.answerFormQuestion({ question, prompt, profile: this.profile, vaultEntry });
+  }
+}

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,8 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('appBridge', {
+  discoverJobs: (filters) => ipcRenderer.invoke('orchestrator:discoverJobs', filters),
+  buildResume: (payload) => ipcRenderer.invoke('orchestrator:buildResume', payload),
+  buildCoverLetter: (payload) => ipcRenderer.invoke('orchestrator:buildCoverLetter', payload),
+  answerQuestion: (payload) => ipcRenderer.invoke('orchestrator:answerQuestion', payload)
+});

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -1,0 +1,75 @@
+const jobListEl = document.getElementById('job-list');
+const scanJobsBtn = document.getElementById('scan-jobs');
+const resumeOutputEl = document.getElementById('resume-output');
+const coverLetterOutputEl = document.getElementById('cover-letter-output');
+const formQuestionEl = document.getElementById('form-question');
+const formAnswerEl = document.getElementById('form-answer');
+const answerFormBtn = document.getElementById('answer-form');
+
+let currentJobs = [];
+let selectedJob;
+
+scanJobsBtn.addEventListener('click', async () => {
+  scanJobsBtn.disabled = true;
+  scanJobsBtn.textContent = 'Taranıyor...';
+  const filters = { location: 'Remote', roles: ['Product', 'Software'] };
+  const results = await window.appBridge.discoverJobs(filters);
+  currentJobs = results;
+  renderJobs();
+  scanJobsBtn.disabled = false;
+  scanJobsBtn.textContent = 'İlanları Tara';
+});
+
+answerFormBtn.addEventListener('click', async () => {
+  if (!selectedJob) {
+    formAnswerEl.textContent = 'Önce bir ilan seçin.';
+    return;
+  }
+  const question = formQuestionEl.value.trim();
+  if (!question) {
+    formAnswerEl.textContent = 'Bir soru yazın.';
+    return;
+  }
+  const response = await window.appBridge.answerQuestion({ question, vaultEntry: null });
+  formAnswerEl.textContent = JSON.stringify(response, null, 2);
+});
+
+function renderJobs() {
+  jobListEl.innerHTML = '';
+  currentJobs.forEach(({ job, match }) => {
+    const li = document.createElement('li');
+    li.className = 'job-card';
+    li.innerHTML = `
+      <h3>${job.title}</h3>
+      <small>${job.company} · ${job.location}</small>
+      <p>Uyum Skoru: ${match.score}%</p>
+      <div class="actions">
+        <button data-action="resume">CV Uyarlama</button>
+        <button data-action="cover">Cover Letter</button>
+        <button data-action="select">Form İçin Seç</button>
+      </div>
+    `;
+
+    li.querySelector('[data-action="resume"]').addEventListener('click', async () => {
+      const result = await window.appBridge.buildResume({ job, resume: 'Varsayılan CV içeriği' });
+      resumeOutputEl.textContent = JSON.stringify(result, null, 2);
+    });
+
+    li.querySelector('[data-action="cover"]').addEventListener('click', async () => {
+      const cover = await window.appBridge.buildCoverLetter({
+        job,
+        achievements: ['Gelir %20 artışı', '3 ürün lansmanı'],
+        tone: 'analitik',
+        language: 'tr'
+      });
+      coverLetterOutputEl.textContent = cover;
+    });
+
+    li.querySelector('[data-action="select"]').addEventListener('click', () => {
+      selectedJob = job;
+      formAnswerEl.textContent = `${job.title} seçildi.`;
+    });
+
+    jobListEl.appendChild(li);
+  });
+}

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Job Applier MVP</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>AI Destekli İş Başvuru Paneli</h1>
+      <button id="scan-jobs">İlanları Tara</button>
+    </header>
+    <main>
+      <section class="column">
+        <h2>Bulunan İlanlar</h2>
+        <ul id="job-list"></ul>
+      </section>
+      <section class="column">
+        <h2>Üretilen Dokümanlar</h2>
+        <div>
+          <h3>CV Uyarlama Çıktısı</h3>
+          <pre id="resume-output" class="output"></pre>
+        </div>
+        <div>
+          <h3>Cover Letter</h3>
+          <pre id="cover-letter-output" class="output"></pre>
+        </div>
+      </section>
+      <section class="column">
+        <h2>Form Yanıtı</h2>
+        <textarea id="form-question" placeholder="Form sorusunu girin"></textarea>
+        <button id="answer-form">Yanıt Öner</button>
+        <pre id="form-answer" class="output"></pre>
+      </section>
+    </main>
+    <footer>
+      <small>Demo: İnsan benzeri otomasyon için Playwright tetiklenmeye hazır.</small>
+    </footer>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,0 +1,107 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #0f172a;
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+header,
+footer {
+  background: rgba(15, 23, 42, 0.9);
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  border-bottom: none;
+  justify-content: center;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.column {
+  background: rgba(30, 41, 59, 0.7);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.6);
+}
+
+button {
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  border: none;
+  color: #0f172a;
+  padding: 0.7rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(34, 211, 238, 0.35);
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.job-card {
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 10px;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.job-card h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+}
+
+.job-card small {
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.output {
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 10px;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  min-height: 120px;
+  white-space: pre-wrap;
+}
+
+textarea {
+  min-height: 120px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.75rem;
+  resize: vertical;
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+}

--- a/tests/data-models.test.js
+++ b/tests/data-models.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createUserProfile,
+  createDefaultSettings,
+  computeMatchScore,
+  summarizePipeline
+} from '../src/data/models.js';
+import { composePrompt } from '../src/llm/promptComposer.js';
+
+test('createUserProfile sets defaults', () => {
+  const profile = createUserProfile({ name: 'Test' });
+  assert.equal(profile.name, 'Test');
+  assert.equal(profile.languages[0].code, 'tr');
+  assert.ok(profile.createdAt);
+});
+
+test('createDefaultSettings merges overrides', () => {
+  const settings = createDefaultSettings({ dailyCap: 5 });
+  assert.equal(settings.dailyCap, 5);
+  assert.equal(settings.provider, 'chatgpt');
+});
+
+test('computeMatchScore calculates percentage', () => {
+  const score = computeMatchScore(
+    { skills: ['Node.js', 'React', 'SQL'] },
+    { skills: ['react', 'playwright', 'node.js'] }
+  );
+  assert.equal(score.score, 67);
+  assert.deepEqual(score.matchedSkills.sort(), ['Node.js', 'React'].sort());
+});
+
+test('summarizePipeline groups status counts', () => {
+  const summary = summarizePipeline([
+    { status: 'found' },
+    { status: 'found' },
+    { status: 'applied' }
+  ]);
+  assert.equal(summary.found, 2);
+  assert.equal(summary.applied, 1);
+});
+
+test('composePrompt replaces variables', () => {
+  const prompt = composePrompt('missing_info', { MISSING_FIELDS_LIST: ['salary', 'noticePeriod'] });
+  assert.ok(prompt.includes('salary'));
+});


### PR DESCRIPTION
## Summary
- document the macOS AI job application system architecture, UI hierarchy, prompts, and QA plan
- scaffold an Electron-based MVP with mock orchestrator, Playwright scraper stubs, data models, and LLM provider abstraction
- add npm tooling, placeholder lint script, and Node tests for key utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2eb788288332b958506c2fd17e6d